### PR TITLE
Avoid constexpr cuda

### DIFF
--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -24,7 +24,7 @@ auto get_extents(InViewType& in, OutViewType& out, axis_type<DIM> _axes) {
   auto [map, map_inv] = KokkosFFT::Impl::get_map_axes(in, _axes);
 
   constexpr std::size_t rank = InViewType::rank;
-  int inner_most_axis =
+  [[maybe_unused]] int inner_most_axis =
       std::is_same_v<array_layout_type, typename Kokkos::LayoutLeft> ? 0
                                                                      : rank - 1;
 
@@ -95,7 +95,7 @@ auto get_extents_batched(InViewType& in, OutViewType& out,
                 "or equal to 1.");
 
   constexpr std::size_t rank = InViewType::rank;
-  int inner_most_axis =
+  [[maybe_unused]] int inner_most_axis =
       std::is_same_v<array_layout_type, typename Kokkos::LayoutLeft>
           ? 0
           : (rank - 1);
@@ -155,7 +155,7 @@ auto get_extents_batched(InViewType& in, OutViewType& out,
                                        1, std::multiplies<>());
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  int howmany  = total_fft_size / fft_size;
+  [[maybe_unused]] int howmany  = total_fft_size / fft_size;
 
   return std::tuple<std::vector<int>, std::vector<int>, std::vector<int>, int>(
       {in_extents, out_extents, fft_extents, howmany});

--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -155,7 +155,7 @@ auto get_extents_batched(InViewType& in, OutViewType& out,
                                        1, std::multiplies<>());
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  [[maybe_unused]] int howmany  = total_fft_size / fft_size;
+  [[maybe_unused]] int howmany = total_fft_size / fft_size;
 
   return std::tuple<std::vector<int>, std::vector<int>, std::vector<int>, int>(
       {in_extents, out_extents, fft_extents, howmany});

--- a/common/src/KokkosFFT_normalization.hpp
+++ b/common/src/KokkosFFT_normalization.hpp
@@ -24,7 +24,7 @@ auto _coefficients(const ViewType& inout, Direction direction,
                    Normalization normalization, std::size_t fft_size) {
   using value_type =
       KokkosFFT::Impl::real_type_t<typename ViewType::non_const_value_type>;
-  value_type coef   = 1;
+  value_type coef                    = 1;
   [[maybe_unused]] bool to_normalize = false;
 
   switch (normalization) {

--- a/common/src/KokkosFFT_normalization.hpp
+++ b/common/src/KokkosFFT_normalization.hpp
@@ -25,7 +25,7 @@ auto _coefficients(const ViewType& inout, Direction direction,
   using value_type =
       KokkosFFT::Impl::real_type_t<typename ViewType::non_const_value_type>;
   value_type coef   = 1;
-  bool to_normalize = false;
+  [[maybe_unused]] bool to_normalize = false;
 
   switch (normalization) {
     case Normalization::FORWARD:

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -165,23 +165,25 @@ void _transpose(const ExecutionSpace& exec_space, InViewType& in,
     auto [_n0, _n1, _n2] = out_extents;
     out                  = OutViewType("out", _n0, _n1, _n2);
   }
+
+  Kokkos::Array<int, 3> map = {_map[0], _map[1], _map[2]};
   Kokkos::parallel_for(
       range, KOKKOS_LAMBDA(int i0, int i1, int i2) {
         int _i0 = i0, _i1 = i1, _i2 = i2;
-        if (_map[0] == 0 && _map[1] == 2 && _map[2] == 1) {
+        if (map[0] == 0 && map[1] == 2 && map[2] == 1) {
           _i1 = i2;
           _i2 = i1;
-        } else if (_map[0] == 1 && _map[1] == 0 && _map[2] == 2) {
+        } else if (map[0] == 1 && map[1] == 0 && map[2] == 2) {
           _i0 = i1;
           _i1 = i0;
-        } else if (_map[0] == 1 && _map[1] == 2 && _map[2] == 0) {
+        } else if (map[0] == 1 && map[1] == 2 && map[2] == 0) {
           _i0 = i1;
           _i1 = i2;
           _i2 = i0;
-        } else if (_map[0] == 2 && _map[1] == 1 && _map[2] == 0) {
+        } else if (map[0] == 2 && map[1] == 1 && map[2] == 0) {
           _i0 = i2;
           _i2 = i0;
-        } else if (_map[0] == 2 && _map[1] == 0 && _map[2] == 1) {
+        } else if (map[0] == 2 && map[1] == 0 && map[2] == 1) {
           _i0 = i2;
           _i1 = i0;
           _i2 = i1;

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -69,7 +69,7 @@ auto convert_negative_shift(const ViewType& view, int _shift, int _axis) {
                 "convert_negative_shift: ViewType is not a Kokkos::View.");
   int axis   = convert_negative_axis(view, _axis);
   int extent = view.extent(axis);
-  int shift0 = 0, shift1 = 0, shift2 = extent / 2;
+  [[maybe_unused]] int shift0 = 0, shift1 = 0, shift2 = extent / 2;
 
   if (_shift < 0) {
     shift0 = -_shift + extent % 2;  // add 1 for odd case

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -67,8 +67,8 @@ template <typename ViewType>
 auto convert_negative_shift(const ViewType& view, int _shift, int _axis) {
   static_assert(Kokkos::is_view<ViewType>::value,
                 "convert_negative_shift: ViewType is not a Kokkos::View.");
-  int axis   = convert_negative_axis(view, _axis);
-  int extent = view.extent(axis);
+  int axis                    = convert_negative_axis(view, _axis);
+  int extent                  = view.extent(axis);
   [[maybe_unused]] int shift0 = 0, shift1 = 0, shift2 = extent / 2;
 
   if (_shift < 0) {

--- a/fft/src/KokkosFFT_Helpers.hpp
+++ b/fft/src/KokkosFFT_Helpers.hpp
@@ -71,8 +71,8 @@ void _roll(const ExecutionSpace& exec_space, ViewType& inout,
   int n0 = inout.extent(0), n1 = inout.extent(1);
 
   ViewType tmp("tmp", n0, n1);
-  int len0 = (n0 - 1) / 2 + 1;
-  int len1 = (n1 - 1) / 2 + 1;
+  [[maybe_unused]] int len0 = (n0 - 1) / 2 + 1;
+  [[maybe_unused]] int len1 = (n1 - 1) / 2 + 1;
 
   using range_type = Kokkos::MDRangePolicy<
       ExecutionSpace,


### PR DESCRIPTION
Fixes #33

Warnings for unused variables are also suppressed by adding `[[maybe_unused]]`