### PR TITLE
Cleanup

### DIFF
--- a/docs/api/helper/fftshift.rst
+++ b/docs/api/helper/fftshift.rst
@@ -1,8 +1,8 @@
 
 KokkosFFT::fftshift
 -------------------
-.. doxygenfunction:: KokkosFFT::fftshift(const ExecutionSpace& exec_space, ViewType& inout)
-.. doxygenfunction:: KokkosFFT::fftshift(const ExecutionSpace& exec_space, ViewType& inout, int axes)
+
+.. doxygenfunction:: KokkosFFT::fftshift(const ExecutionSpace& exec_space, ViewType& inout, std::optional<int> axes = std::nullopt)
 .. doxygenfunction:: KokkosFFT::fftshift(const ExecutionSpace& exec_space, ViewType& inout, axis_type<DIM> axes)
 
 .. note::

--- a/docs/api/helper/ifftshift.rst
+++ b/docs/api/helper/ifftshift.rst
@@ -2,8 +2,7 @@
 KokkosFFT::ifftshift
 --------------------
 
-.. doxygenfunction:: KokkosFFT::ifftshift(const ExecutionSpace& exec_space, ViewType& inout)
-.. doxygenfunction:: KokkosFFT::ifftshift(const ExecutionSpace& exec_space, ViewType& inout, int axes)
+.. doxygenfunction:: KokkosFFT::ifftshift(const ExecutionSpace& exec_space, ViewType& inout, std::optional<int> axes = std::nullopt)
 .. doxygenfunction:: KokkosFFT::ifftshift(const ExecutionSpace& exec_space, ViewType& inout, axis_type<DIM> axes)
 
 .. note::

--- a/docs/intro/building.rst
+++ b/docs/intro/building.rst
@@ -108,43 +108,35 @@ If CMake fails to find a backend FFT library, see :doc:`How to find fft librarie
 We may support experimental backends like ``OPENMPTARGET`` in the future.
  
 .. list-table:: ``Host backend``
-   :widths: 25 25 25 25
+   :widths: 25 50 25
    :header-rows: 1
 
    * - CMake option
      - Description
      - Backend FFT library
-     - Default
    * - ``Kokkos_ENABLE_SERIAL``
      - Serial backend targeting CPUs 
      - ``fftw (Serial)``
-     - OFF
    * - ``Kokkos_ENABLE_THREADS``
      - C++ threads backend targeting CPUs 
      - ``fftw (Threads)``
-     - OFF
    * - ``Kokkos_ENABLE_OPENMP``
      - OpenMP backend targeting CPUs 
      - ``fftw (OpenMP)``
-     - OFF
 
 .. list-table:: ``Device backend``
-   :widths: 25 25 25 25
+   :widths: 25 50 25
    :header-rows: 1
 
    * - CMake option
      - Description
      - Backend FFT library
-     - Default
    * - ``Kokkos_ENABLE_CUDA``
      - CUDA backend targeting NVIDIA GPUs
      - ``cufft``
-     - OFF
    * - ``Kokkos_ENABLE_HIP``
      - HIP backend targeting AMD GPUs
      - ``hipfft``
-     - OFF
    * - ``Kokkos_ENABLE_SYCL``
      - SYCL backend targeting Intel GPUs
      - ``oneMKL``
-     - OFF

--- a/docs/intro/building.rst
+++ b/docs/intro/building.rst
@@ -4,7 +4,7 @@ Building KokkosFFT
 ==================
 
 This section describes how to build KokkosFFT with some advanced options.
-In order to build KokkosFFT, we use CMake with following compilers. 
+In order to build KokkosFFT, we use ``CMake`` with following compilers. 
 Kokkos and backend FFT libraries are also necessary.
 Available CMake options for KokkosFFT are listed. 
 

--- a/docs/intro/quick_start.rst
+++ b/docs/intro/quick_start.rst
@@ -26,8 +26,8 @@ Here are list of compilers we frequently use for testing.
 * ``nvcc 12.0.0+`` - NVIDIA GPUs
 * ``rocm 5.3.0+`` - AMD GPUs
 
-Building KokkosFFT
-------------------
+Building
+--------
 
 For the moment, there are two ways to use KokkosFFT: including as a subdirectory in CMake project or installing as a library.
 For simplicity, however, we demonstrate an example to use KokkosFFT as a subdirectory in a CMake project. For installation, see :ref:`Building KokkosFFT<building>` for detail.
@@ -72,8 +72,8 @@ For compilation, we basically rely on the CMake options for Kokkos. For example,
 
 This way, all the functionalities are executed on A100 GPUs.
 
-Trying KokkosFFT
-----------------
+Trying
+------
 
 For those who are familiar with `numpy.fft <https://numpy.org/doc/stable/reference/routines.fft.html>`_, 
 you may use KokkosFFT quite easily. Here is an example for 1D real to complex transform with rfft in python and KokkosFFT.

--- a/docs/intro/using.rst
+++ b/docs/intro/using.rst
@@ -48,7 +48,9 @@ The following listing shows good and bad examples of Real FFTs.
    // [NG, Compile time error] Inconsistent types
    // Input: double (NG) -> complex<double> (OK)
    // Output: complex<double> (NG) -> double (OK)
-   //KokkosFFT::irfft2(execution_space(), x_hat_good, x);
+   //KokkosFFT::irfft2(execution_space(), x, x_hat_good);
+   // [OK] Correct types and extents
+   KokkosFFT::irfft2(execution_space(), x_hat_good, x);
 
    // [NG, Run time error] Inconsistent extetns
    // Output: (n0, n1) (NG) -> (n0, n1/2+1) (OK)
@@ -65,7 +67,8 @@ Supported data types
 Firstly, the input and output Views must have the same LayoutType and rank.
 For the moment, we accept Kokkos Views with some restriction in data types and Layout.
 Here are the list of available types for Views. We recommend to use dynamic allocation for Views,
-since we have not tested with static shaped Views. In addition, we have not tested with non-default `Memory Traits<https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/ProgrammingModel.html#memory-traits>`_
+since we have not tested with static shaped Views. In addition, we have not tested with non-default 
+`Memory Traits <https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/ProgrammingModel.html#memory-traits>`_.
 
 * DataType: ``float``, ``double``, ``Kokkos::complex<float>``, ``Kokkos::complex<double>``
 * LayoutType: ``Kokkos::LayoutLeft``, ``Kokkos::LayoutRight``

--- a/fft/src/KokkosFFT_Helpers.hpp
+++ b/fft/src/KokkosFFT_Helpers.hpp
@@ -235,22 +235,18 @@ auto rfftfreq(const ExecutionSpace& exec_space, const std::size_t n,
 ///
 /// \param exec_space [in] Kokkos execution space
 /// \param inout [in,out] Spectrum
+/// \param axes [in] Axes over which to shift, optional
 template <typename ExecutionSpace, typename ViewType>
-void fftshift(const ExecutionSpace& exec_space, ViewType& inout) {
-  constexpr std::size_t rank = ViewType::rank();
-  constexpr int start        = -static_cast<int>(rank);
-  axis_type<rank> axes       = KokkosFFT::Impl::index_sequence<rank>(start);
-  KokkosFFT::Impl::_fftshift(exec_space, inout, axes);
-}
-
-/// \brief Shift the zero-frequency component to the center of the spectrum
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param inout [in,out] Spectrum
-/// \param axes [in] Axes over which to shift
-template <typename ExecutionSpace, typename ViewType>
-void fftshift(const ExecutionSpace& exec_space, ViewType& inout, int axes) {
-  KokkosFFT::Impl::_fftshift(exec_space, inout, axis_type<1>{axes});
+void fftshift(const ExecutionSpace& exec_space, ViewType& inout, std::optional<int> axes = std::nullopt) {
+  if (axes) {
+    axis_type<1> _axes {axes.value()};
+    KokkosFFT::Impl::_fftshift(exec_space, inout, _axes);
+  } else {
+    constexpr std::size_t rank = ViewType::rank();
+    constexpr int start        = -static_cast<int>(rank);
+    axis_type<rank> _axes      = KokkosFFT::Impl::index_sequence<rank>(start);
+    KokkosFFT::Impl::_fftshift(exec_space, inout, _axes);
+  }
 }
 
 /// \brief Shift the zero-frequency component to the center of the spectrum
@@ -268,22 +264,18 @@ void fftshift(const ExecutionSpace& exec_space, ViewType& inout,
 ///
 /// \param exec_space [in] Kokkos execution space
 /// \param inout [in,out] Spectrum
+/// \param axes [in] Axes over which to shift, optional
 template <typename ExecutionSpace, typename ViewType>
-void ifftshift(const ExecutionSpace& exec_space, ViewType& inout) {
-  constexpr std::size_t rank = ViewType::rank();
-  constexpr int start        = -static_cast<int>(rank);
-  axis_type<rank> axes       = KokkosFFT::Impl::index_sequence<rank>(start);
-  KokkosFFT::Impl::_ifftshift(exec_space, inout, axes);
-}
-
-/// \brief The inverse of fftshift
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param inout [in,out] Spectrum
-/// \param axes [in] Axes over which to shift
-template <typename ExecutionSpace, typename ViewType>
-void ifftshift(const ExecutionSpace& exec_space, ViewType& inout, int axes) {
-  KokkosFFT::Impl::_ifftshift(exec_space, inout, axis_type<1>{axes});
+void ifftshift(const ExecutionSpace& exec_space, ViewType& inout, std::optional<int> axes = std::nullopt) {
+  if (axes) {
+    axis_type<1> _axes {axes.value()};
+    KokkosFFT::Impl::_ifftshift(exec_space, inout, _axes);
+  } else {
+    constexpr std::size_t rank = ViewType::rank();
+    constexpr int start        = -static_cast<int>(rank);
+    axis_type<rank> _axes      = KokkosFFT::Impl::index_sequence<rank>(start);
+    KokkosFFT::Impl::_ifftshift(exec_space, inout, _axes);
+  }
 }
 
 /// \brief The inverse of fftshift


### PR DESCRIPTION
In this PR, 

1. Overloads of `fftshift` and `ifftshift` removed. docs are updated accordingly
2. Minor fix in docs